### PR TITLE
Close done channel for non-streaming responses.

### DIFF
--- a/server.go
+++ b/server.go
@@ -435,6 +435,7 @@ func (s *service) call(c call) {
 		}
 		c.server.sendResponse(c.sending, c.req, c.replyv.Interface(), c.codec, errmsg, true)
 		c.server.freeRequest(c.req)
+		close(c.done)
 		return
 	}
 


### PR DESCRIPTION
This should fix the memory leak in discoverd: https://github.com/flynn/discoverd/issues/48

Closes flynn/discoverd#48
